### PR TITLE
Feature: Granular gesture controls for Mission Control and Space Navigation

### DIFF
--- a/Core/EventHandling/GestureHandler.swift
+++ b/Core/EventHandling/GestureHandler.swift
@@ -65,7 +65,10 @@ final class GestureHandler: NSObject {
                 let dx = abs(mouseLocation.x - startLocation.x)
                 let dy = abs(mouseLocation.y - startLocation.y)
                 if hypot(dx, dy) < 5 {
-                    SystemActionRunner.activateMissionControl()
+                    // Only activate Mission Control if enabled in settings
+                    if settingsManager?.enableMissionControl == true {
+                        SystemActionRunner.activateMissionControl()
+                    }
                 }
                 currentState = .idle
                 return .consumed
@@ -104,11 +107,14 @@ final class GestureHandler: NSObject {
                 let deltaX = mouseLocation.x - startLocation.x
                 let threshold = settingsManager?.dragThreshold ?? 40.0
                 if abs(deltaX) > CGFloat(threshold) {
-                    let invertDirection = settingsManager?.invertDragDirection ?? false
-                    if deltaX > 0 {
-                        invertDirection ? SystemActionRunner.moveToPreviousSpace() : SystemActionRunner.moveToNextSpace()
-                    } else {
-                        invertDirection ? SystemActionRunner.moveToNextSpace() : SystemActionRunner.moveToPreviousSpace()
+                    // Only switch spaces if enabled in settings
+                    if settingsManager?.enableSpaceNavigation == true {
+                        let invertDirection = settingsManager?.invertDragDirection ?? false
+                        if deltaX > 0 {
+                            invertDirection ? SystemActionRunner.moveToPreviousSpace() : SystemActionRunner.moveToNextSpace()
+                        } else {
+                            invertDirection ? SystemActionRunner.moveToNextSpace() : SystemActionRunner.moveToPreviousSpace()
+                        }
                     }
                     currentState = .idle
                     return .consumed

--- a/Core/Settings/SettingsManager.swift
+++ b/Core/Settings/SettingsManager.swift
@@ -48,7 +48,21 @@ final class SettingsManager: ObservableObject, SettingsProtocol {
     @Published var enableScrollZoom: Bool = UserDefaults.standard.bool(forKey: "enableScrollZoom") {
         didSet { UserDefaults.standard.set(enableScrollZoom, forKey: "enableScrollZoom") }
     }
-    
+
+    @Published var enableMissionControl: Bool = {
+        let value = UserDefaults.standard.object(forKey: "enableMissionControl")
+        return value as? Bool ?? true
+    }() {
+        didSet { UserDefaults.standard.set(enableMissionControl, forKey: "enableMissionControl") }
+    }
+
+    @Published var enableSpaceNavigation: Bool = {
+        let value = UserDefaults.standard.object(forKey: "enableSpaceNavigation")
+        return value as? Bool ?? true
+    }() {
+        didSet { UserDefaults.standard.set(enableSpaceNavigation, forKey: "enableSpaceNavigation") }
+    }
+
     @Published var isDarkMode: Bool = UserDefaults.standard.bool(forKey: "isDarkMode") {
         didSet { 
             UserDefaults.standard.set(isDarkMode, forKey: "isDarkMode")

--- a/Core/Settings/SettingsProtocol.swift
+++ b/Core/Settings/SettingsProtocol.swift
@@ -10,9 +10,11 @@ protocol SettingsProtocol: ObservableObject {
     var dragThreshold: Double { get set }
     var invertScroll: Bool { get set }
     var enableScrollZoom: Bool { get set }
+    var enableMissionControl: Bool { get set }
+    var enableSpaceNavigation: Bool { get set }
     var isDarkMode: Bool { get set }
     var followSystemAppearance: Bool { get set }
-    
+
     func moveToMenuBar()
     func updateLaunchAtLogin(_ enabled: Bool)
 } 

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -293,21 +293,39 @@ struct SettingsView<Settings: SettingsProtocol>: View {
 
     private var mouseBox: some View {
         ModernCard(
-            title: "Mouse & Drag",
+            title: "Gestures & Navigation",
             icon: "cursorarrow.motionlines.click",
             gradientColors: GradientCache.mouseGradient,
             isHovered: hoveredCard == "mouse"
         ) {
             VStack(alignment: .leading, spacing: 20) {
                 ModernToggle(
+                    isOn: $settings.enableMissionControl,
+                    label: "Enable Mission Control",
+                    icon: "macwindow.badge.plus",
+                    description: "Activate with middle mouse click"
+                )
+                .disabled(!settings.isMonitoringActive)
+                .opacity(settings.isMonitoringActive ? 1.0 : 0.5)
+
+                ModernToggle(
+                    isOn: $settings.enableSpaceNavigation,
+                    label: "Enable Space Navigation",
+                    icon: "square.3.layers.3d",
+                    description: "Switch spaces with middle drag"
+                )
+                .disabled(!settings.isMonitoringActive)
+                .opacity(settings.isMonitoringActive ? 1.0 : 0.5)
+
+                ModernToggle(
                     isOn: $settings.invertDragDirection,
                     label: "Invert drag direction",
                     icon: "arrow.left.and.right.circle",
                     description: "Reverse horizontal drag behavior"
                 )
-                .disabled(!settings.isMonitoringActive)
-                .opacity(settings.isMonitoringActive ? 1.0 : 0.5)
-                
+                .disabled(!settings.isMonitoringActive || !settings.enableSpaceNavigation)
+                .opacity(settings.isMonitoringActive && settings.enableSpaceNavigation ? 1.0 : 0.5)
+
                 VStack(alignment: .leading, spacing: 12) {
                     HStack {
                         Image(systemName: "slider.horizontal.below.square.filled.and.square")
@@ -322,10 +340,10 @@ struct SettingsView<Settings: SettingsProtocol>: View {
                             .padding(.vertical, 4)
                             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
                     }
-                    
+
                     Slider(value: $settings.dragThreshold, in: 0...500, step: 5)
                         .tint(.purple)
-                        .disabled(!settings.isMonitoringActive)
+                        .disabled(!settings.isMonitoringActive || !settings.enableSpaceNavigation)
                         .accessibilityLabel("Drag threshold slider")
                         .accessibilityHint("Adjusts sensitivity for gesture recognition")
                         .accessibilityValue("\(Int(settings.dragThreshold)) pixels")


### PR DESCRIPTION
## ✨ Feature: Granular Gesture Controls

### Overview
Adds independent toggle controls for Mission Control and Space Navigation gestures, allowing users to enable/disable these features individually instead of controlling everything with a single global switch.

### Motivation
Previously, the `isMonitoringActive` toggle controlled **all** gesture features globally. Users had no way to:
- Keep scroll inversion active while disabling Mission Control
- Disable space navigation while keeping Mission Control enabled
- Fine-tune their gesture preferences independently

This feature addresses user request: *"I want invert scroll but don't want Mission Control and space switching"*

### What's New

#### 1. **Independent Mission Control Toggle** 🖱️
- Enable/disable middle mouse click to activate Mission Control
- Default: **Enabled** (maintains backward compatibility)
- Icon: `macwindow.badge.plus`

#### 2. **Independent Space Navigation Toggle** 🎯
- Enable/disable middle mouse drag for workspace switching
- Default: **Enabled** (maintains backward compatibility)  
- Icon: `square.3.layers.3d`

#### 3. **Smart UI Dependencies** 🧠
- "Invert drag direction" now depends on Space Navigation being enabled
- "Drag Sensitivity" slider is only active when Space Navigation is enabled
- Proper visual feedback with opacity changes when disabled

#### 4. **Enhanced Section Organization** 📋
- Renamed "Mouse & Drag" → **"Gestures & Navigation"** for better clarity
- Logical grouping of related gesture controls

### Implementation Details

#### Backend Changes

**SettingsProtocol.swift**
```swift
var enableMissionControl: Bool { get set }
var enableSpaceNavigation: Bool { get set }
```

**SettingsManager.swift**
```swift
@Published var enableMissionControl: Bool = {
    let value = UserDefaults.standard.object(forKey: "enableMissionControl")
    return value as? Bool ?? true // Default: enabled
}() {
    didSet { UserDefaults.standard.set(enableMissionControl, forKey: "enableMissionControl") }
}

@Published var enableSpaceNavigation: Bool = {
    let value = UserDefaults.standard.object(forKey: "enableSpaceNavigation")
    return value as? Bool ?? true // Default: enabled
}() {
    didSet { UserDefaults.standard.set(enableSpaceNavigation, forKey: "enableSpaceNavigation") }
}
```

#### Gesture Logic Updates

**GestureHandler.swift - Mission Control**
```swift
if hypot(dx, dy) < 5 {
    // Only activate Mission Control if enabled in settings
    if settingsManager?.enableMissionControl == true {
        SystemActionRunner.activateMissionControl()
    }
}
```

**GestureHandler.swift - Space Navigation**
```swift
if abs(deltaX) > CGFloat(threshold) {
    // Only switch spaces if enabled in settings
    if settingsManager?.enableSpaceNavigation == true {
        let invertDirection = settingsManager?.invertDragDirection ?? false
        // ... navigation logic
    }
}
```

#### UI Changes

**ContentView.swift**
- Added `ModernToggle` for Mission Control
- Added `ModernToggle` for Space Navigation
- Made drag direction toggle dependent on Space Navigation
- Made sensitivity slider dependent on Space Navigation
- Updated card title and organization

### User Experience

#### Before
```
[ ] Enable gesture monitoring (all or nothing)
    ├── Invert drag direction
    └── Drag sensitivity
```

#### After
```
[ ] Enable gesture monitoring (master switch)
    ├── [✓] Enable Mission Control
    ├── [✓] Enable Space Navigation
    ├── [ ] Invert drag direction (requires Space Nav)
    └── Drag sensitivity (requires Space Nav)
```

### Use Cases

1. **User wants scroll inversion only**
   - Enable monitoring ✓
   - Disable Mission Control ✗
   - Disable Space Navigation ✗
   - Enable invert scroll ✓

2. **User wants Mission Control but no space switching**
   - Enable monitoring ✓
   - Enable Mission Control ✓
   - Disable Space Navigation ✗

3. **Power user wants everything**
   - Enable monitoring ✓
   - Enable Mission Control ✓
   - Enable Space Navigation ✓
   - Configure as needed ✓

### Testing
- ✅ Mission Control can be disabled independently
- ✅ Space Navigation can be disabled independently
- ✅ Settings persist across app restarts
- ✅ Backward compatibility maintained (both default to enabled)
- ✅ UI properly reflects dependencies
- ✅ Scroll inversion works independently
- ✅ No regression in existing functionality

### Files Changed
- `Core/Settings/SettingsProtocol.swift` - Added protocol properties
- `Core/Settings/SettingsManager.swift` - Implemented settings with persistence
- `Core/EventHandling/GestureHandler.swift` - Added conditional checks
- `Views/ContentView.swift` - New UI toggles and dependencies

### Migration
No migration needed - both new settings default to `true`, maintaining existing behavior for current users.

### Screenshots
UI now shows:
- 🎛️ Enable Mission Control toggle
- 🎯 Enable Space Navigation toggle  
- 🔄 Invert drag direction (dependent)
- 📏 Drag Sensitivity slider (dependent)

---

**Type:** Feature Enhancement  
**Breaking Changes:** None  
**Backward Compatible:** Yes  
**User Requested:** Yes