### PR TITLE
fix: remove side mouse buttons functionality to use native macOS behavior

### DIFF
--- a/Core/SystemActions/SystemActionRunner.swift
+++ b/Core/SystemActions/SystemActionRunner.swift
@@ -19,32 +19,7 @@ final class SystemActionRunner {
     static func activateMissionControl() {
         runAppleScript(source: "tell application \"Mission Control\" to launch")
     }
-    
-    // MARK: - Navigation
-    static func goBack() {
-        let source = CGEventSource(stateID: .hidSystemState)
-        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 123, keyDown: true)
-        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 123, keyDown: false)
-        
-        keyDown?.flags = .maskCommand
-        keyUp?.flags = .maskCommand
-        
-        keyDown?.post(tap: .cghidEventTap)
-        keyUp?.post(tap: .cghidEventTap)
-    }
-    
-    static func goForward() {
-        let source = CGEventSource(stateID: .hidSystemState)
-        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 124, keyDown: true)
-        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 124, keyDown: false)
-        
-        keyDown?.flags = .maskCommand
-        keyUp?.flags = .maskCommand
-        
-        keyDown?.post(tap: .cghidEventTap)
-        keyUp?.post(tap: .cghidEventTap)
-    }
-    
+
     // MARK: - Zoom
     static func zoomIn() {
         let source = CGEventSource(stateID: .hidSystemState)


### PR DESCRIPTION
## 🐛 Bug Fix

This PR removes the custom handling of side mouse buttons (buttons 3 and 4) to allow native macOS back/forward navigation to work properly.

### 🔧 Changes Made

**Removed from `GestureHandler.swift`:**
- `ButtonState` struct and button state tracking
- `handleLateralButton()`, `handleButtonDown()`, and `handleButtonUp()` methods
- Side button handling logic and debounce constants
- Debug logging for button events

**Removed from `SystemActionRunner.swift`:**
- `goBack()` and `goForward()` methods

### ✅ Impact

**Before:** Side buttons were intercepted and simulated Cmd+Left/Right, which could interfere with native macOS behavior

**After:** Side buttons pass through to the system without interception, allowing native macOS back/forward navigation

### 🧪 Testing

All other gestures remain functional:
- ✅ Middle click → Mission Control
- ✅ Middle drag → Space navigation  
- ✅ Ctrl+Click drag → Scroll
- ✅ Ctrl+Scroll → Zoom
- ✅ Scroll inversion

### 📊 Code Changes
- 2 files changed, 3 insertions(+), 182 deletions(-)
- Removed ~180 lines of unused button handling code

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)