### PR TITLE
chore(dev): standardize local install workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,28 @@
-# Xcode
-#
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+# BuenMouse - public repo hygiene
 
-## User settings
-xcuserdata/
+# macOS system files
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+Icon
+.DocumentRevisions-V100
+.fseventsd
+.TemporaryItems
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
 
-## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
-*.xcscmblueprint
-*.xccheckout
-
-## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+# Xcode build output and user state
 build/
+build_check/
 DerivedData/
-*.moved-aside
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -21,149 +31,107 @@ DerivedData/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-
-## Obj-C/Swift specific
+xcuserdata/
+*.xcuserstate
+*.xccheckout
+*.moved-aside
+*.xcscmblueprint
 *.hmap
-
-## App packaging
-*.ipa
-*.dSYM.zip
 *.dSYM
+*.dSYM.zip
+*.xcarchive
+*.xcresult
+*.xcdistributionlogs
 
-## Playgrounds
-timeline.xctimeline
-playground.xcworkspace
+# Local signing/provisioning
+*.mobileprovision
+*.provisionprofile
+*.cer
+*.p12
+*.pem
+*.key
+*.xcconfig.local
+Local.xcconfig
+Signing.xcconfig
 
 # Swift Package Manager
-#
-# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
-# *.xcodeproj
-#
-# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
-# hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
-
 .build/
+.swiftpm/
+Packages/
+Package.resolved
 
-# CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# Pods/
-#
-# Add this line if you want to avoid checking in source code from the Xcode workspace
-# *.xcworkspace
-
-# Carthage
-#
-# Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
-
+# CocoaPods / Carthage / Accio
+Pods/
 Carthage/Build/
-
-# Accio dependency management
+Carthage/Checkouts/
 Dependencies/
 .accio/
 
 # fastlane
-#
-# It is recommended to not store the screenshots in the git repo.
-# Instead, use fastlane to re-generate the screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/#source-control
-
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 
-# Code Injection
-#
-# After new code Injection tools there's a generated folder /iOSInjectionProject
-# https://github.com/johnno1962/injectionforxcode
-
+# Playgrounds / injection
+timeline.xctimeline
+playground.xcworkspace
 iOSInjectionProject/
 
-# macOS specific
-.DS_Store
-.AppleDouble
-.LSOverride
+# Sensitive files
+.env
+.env.*
+.env.local
+.env.production
+secrets/
+credentials/
+*.credentials.json
+*credentials*.json
+*service-account*.json
 
-# Icon must end with two \r
-Icon
+# Crash reports and logs
+*.crash
+*.log
+logs/
 
-# Thumbnails
-._*
+# Archives and distribution artifacts
+*.app
+*.ipa
+*.zip
+*.tar.gz
+*.dmg
+*.pkg
+*.rar
 
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-
-# IDEs
-.vscode/
-.idea/
-*.swp
-*.swo
-*~
-
-# Backup files
+# Temporary and backup files
+*.tmp
+*.temp
+tmp/
+temp/
 *.bak
 *.backup
 *.orig
 
-# Log files
-*.log
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.kiro/
+.mcp.json
 
-# Temporary files
-*.tmp
-*.temp
+# Local AI/editor context
+.agent/
+.agents/
+.codex/
+.cursor/
+.claude/
+.superpowers/
 
-# Archive files (unless specifically needed)
-*.zip
-*.tar.gz
-*.rar
-
-# Build artifacts
-*.app
-*.dmg
-*.pkg
-
-# Personal notes and documentation
+# Personal notes (local only)
 NOTES.md
 TODO.md
 PERSONAL_README.md
-
-# Environment files
-.env
-.env.local
-.env.production
-
-# Kiro IDE specific
-.kiro/
-
-# Claude Code
-.claude/
-
-# MCP Configuration
-.mcp.json
-
-# Project documentation (keep local only)
 CLAUDE.md
 AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -133,5 +133,3 @@ temp/
 NOTES.md
 TODO.md
 PERSONAL_README.md
-CLAUDE.md
-AGENTS.md

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,79 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentBlankLines" : false,
+  "indentConditionalCompilationBlocks" : true,
+  "indentSwitchCaseLabels" : false,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "lineBreakAroundMultilineExpressionChainComponents" : false,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : false,
+  "lineBreakBeforeEachGenericRequirement" : false,
+  "lineBreakBetweenDeclarationAttributes" : false,
+  "lineLength" : 140,
+  "maximumBlankLines" : 1,
+  "multiElementCollectionTrailingCommas" : true,
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "orderedImports" : {
+    "includeConditionalImports" : false
+  },
+  "prioritizeKeepingFunctionOutputTogether" : false,
+  "reflowMultilineStringLiterals" : "never",
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : false,
+    "AlwaysUseLiteralForEmptyCollectionInit" : false,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "AvoidRetroactiveConformances" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : false,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileScopedDeclarationPrivacy" : false,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : false,
+    "IdentifiersMustBeASCII" : false,
+    "NeverForceUnwrap" : false,
+    "NeverUseForceTry" : false,
+    "NeverUseImplicitlyUnwrappedOptionals" : false,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoAssignmentInExpressions" : true,
+    "NoBlockComments" : false,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyLinesOpeningClosingBraces" : false,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : false,
+    "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : false,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : false,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
+    "UseEarlyExits" : false,
+    "UseExplicitNilCheckInConditions" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : false,
+    "UseTripleSlashForDocumentationComments" : true,
+    "UseWhereClausesInForLoops" : false,
+    "ValidateDocumentationComments" : false
+  },
+  "spacesAroundRangeFormationOperators" : false,
+  "spacesBeforeEndOfLineComments" : 2,
+  "tabWidth" : 8,
+  "version" : 1
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# BuenMouse Agent Guide
+
+Public-safe operating notes for coding agents. Keep private machine-specific
+workflows, signing material, logs, crash reports, release artifacts, and local
+planning in ignored local files. Speak Spanish with Steven; write code,
+commits, changelogs, and durable technical docs in English.
+
+## Product
+
+- macOS menu bar app for advanced mouse gestures.
+- Minimum macOS: 13.0.
+- UI stack: SwiftUI + AppKit.
+- Main target: `BuenMouse` in `BuenMouse.xcodeproj`.
+- Status-bar-first app; no Dock icon.
+- Accessibility and Input Monitoring permissions are required for gesture
+  handling.
+
+## Architecture
+
+- `BuenMouseApp.swift`: app entry point.
+- `AppDelegate.swift`: window lifecycle and menu bar dropdown.
+- `ServiceManager.swift`: launch-at-login integration.
+- `Core/EventHandling`: event tap setup, gesture state, scroll inversion, and
+  Ctrl-scroll zoom.
+- `Core/Permissions`: Accessibility onboarding and System Settings helper UI.
+- `Core/Settings`: persisted settings and protocol surface for views.
+- `Core/SystemActions`: local macOS actions such as Mission Control / Spaces.
+- `Views`: settings surface, gesture previews, and permission requirements UI.
+
+## Guardrails
+
+- Keep gesture behavior local to macOS. Do not add cloud relay, telemetry, or
+  credential storage without explicit design approval.
+- Do not commit certificates, provisioning profiles, Team IDs, local Xcode user
+  data, logs, crash reports, DMGs, archives, or environment files.
+- Do not add an in-app changelog or "What's New" surface; release notes belong
+  in `CHANGELOG.md` and GitHub Releases.
+- Preserve the status-bar-first workflow and focused settings surface.
+- Side mouse buttons 3/4 are intentionally left to native macOS back/forward
+  behavior.
+- Ask before installing, relaunching, committing, pushing, merging, tagging, or
+  publishing a release.
+
+## Build And Verification
+
+Use the Makefile for the standard local gate:
+
+```bash
+make ci-check
+```
+
+- `make ci-check` runs Swift formatting lint plus a Release build.
+- The project does not have a unit test target yet; there is no `make test`
+  gate.
+- Use `make format` / `make lint` before commits; optional Lefthook via
+  `make hooks-install`.
+- Run `git diff --check` before staging or reporting a patch done.
+
+Direct build command:
+
+```bash
+xcodebuild -project BuenMouse.xcodeproj -scheme BuenMouse \
+  -configuration Release -destination 'generic/platform=macOS' \
+  -derivedDataPath ./build_check build
+```
+
+## Local Testing
+
+Install or relaunch the app only when Steven explicitly asks. Reinstalling to
+the same `/Applications/BuenMouse.app` path with the same signing identity should
+preserve existing macOS permissions.
+
+Useful runtime log stream:
+
+```bash
+/usr/bin/log stream --style compact --predicate 'process == "BuenMouse"'
+```
+
+Crash reports land under `~/Library/Logs/DiagnosticReports/BuenMouse-*.ips`.
+
+## Documentation
+
+- Keep `CHANGELOG.md` in Keep a Changelog style with `[Unreleased]` at the top.
+- Record meaningful user-facing, maintainer, permission, or release workflow
+  changes.
+- Keep README, contributor docs, security notes, and release notes aligned with
+  actual behavior.
+- Keep this guide compact and public-safe; move long runbooks or private
+  workflows into ignored local docs.
+
+## Release
+
+- Build and validate the Release app before packaging.
+- DMGs are release-only; do not create one for routine local verification.
+- Use the existing `create-dmg` release flow if Steven approves release
+  packaging.
+- Do not create GitHub releases, tags, or release notes without explicit
+  approval.
+
+## Git
+
+- Do not run `git add`, commit, push, PR creation, merge, rebase, reset, branch
+  deletion, tag, or release publication without explicit approval.
+- Do not revert unrelated user changes.
+- Use Conventional Commits if asked to commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,11 @@ xcodebuild -project BuenMouse.xcodeproj -scheme BuenMouse \
 
 ## Local Testing
 
-Install or relaunch the app only when Steven explicitly asks. Reinstalling to
-the same `/Applications/BuenMouse.app` path with the same signing identity should
-preserve existing macOS permissions.
+Use `make install-dev` for routine local app testing on Steven's Mac after he
+has approved installation/relaunch for the task. It builds a signed Release app,
+reinstalls to `/Applications/BuenMouse.app`, and relaunches it. Keeping the same
+app name, bundle id, and Apple Development signing identity preserves
+Accessibility and Input Monitoring grants across rebuilds.
 
 Useful runtime log stream:
 
@@ -92,8 +94,7 @@ Crash reports land under `~/Library/Logs/DiagnosticReports/BuenMouse-*.ips`.
 
 - Build and validate the Release app before packaging.
 - DMGs are release-only; do not create one for routine local verification.
-- Use the existing `create-dmg` release flow if Steven approves release
-  packaging.
+- Use `make notarized-dmg` only when Steven approves release packaging.
 - Do not create GitHub releases, tags, or release notes without explicit
   approval.
 

--- a/BuenMouse.xcodeproj/project.pbxproj
+++ b/BuenMouse.xcodeproj/project.pbxproj
@@ -13,9 +13,10 @@
 		B0814B5F2E14B64400112727 /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0814B5B2E14B64400112727 /* WindowAccessor.swift */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXFileReference section */
-		B06242CF2E0241D00061FE50 /* BuenMouse.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BuenMouse.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		B0814B582E14B64400112727 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+	/* Begin PBXFileReference section */
+			B06242CF2E0241D00061FE50 /* BuenMouse.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BuenMouse.app; sourceTree = BUILT_PRODUCTS_DIR; };
+			B0AA51A6516000000000000C /* SigningDefaults.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SigningDefaults.xcconfig; sourceTree = "<group>"; };
+			B0814B582E14B64400112727 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B0814B592E14B64400112727 /* BuenMouseApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuenMouseApp.swift; sourceTree = "<group>"; };
 		B0814B5A2E14B64400112727 /* ServiceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceManager.swift; sourceTree = "<group>"; };
 		B0814B5B2E14B64400112727 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
@@ -68,8 +69,9 @@
 			children = (
 				B0814B7C2E14B88800112727 /* Core */,
 				B0814B842E14B88C00112727 /* Views */,
-				B0FF76AA2E04CB480058666B /* Resources */,
-				B0814B582E14B64400112727 /* AppDelegate.swift */,
+					B0FF76AA2E04CB480058666B /* Resources */,
+					B0AA51A6516000000000000C /* SigningDefaults.xcconfig */,
+					B0814B582E14B64400112727 /* AppDelegate.swift */,
 				B0814B592E14B64400112727 /* BuenMouseApp.swift */,
 				B0814B5A2E14B64400112727 /* ServiceManager.swift */,
 				B0814B5B2E14B64400112727 /* WindowAccessor.swift */,
@@ -171,9 +173,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		B06242EF2E0241D10061FE50 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
+			B06242EF2E0241D10061FE50 /* Debug */ = {
+				isa = XCBuildConfiguration;
+				baseConfigurationReference = B0AA51A6516000000000000C /* SigningDefaults.xcconfig */;
+				buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -206,8 +209,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = NXT93S55FY;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
+					ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -235,9 +237,10 @@
 			};
 			name = Debug;
 		};
-		B06242F02E0241D10061FE50 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
+			B06242F02E0241D10061FE50 /* Release */ = {
+				isa = XCBuildConfiguration;
+				baseConfigurationReference = B0AA51A6516000000000000C /* SigningDefaults.xcconfig */;
+				buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -270,8 +273,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = NXT93S55FY;
-				ENABLE_NS_ASSERTIONS = NO;
+					ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -294,15 +296,13 @@
 		B06242F22E0241D10061FE50 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = Resources/BuenMouse.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-					CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = NXT93S55FY;
-				ENABLE_HARDENED_RUNTIME = YES;
+					ARCHS = arm64;
+					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+					ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+					CODE_SIGN_ENTITLEMENTS = Resources/BuenMouse.entitlements;
+					COMBINE_HIDPI_IMAGES = YES;
+						CURRENT_PROJECT_VERSION = 2;
+					ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -325,15 +325,13 @@
 		B06242F32E0241D10061FE50 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = Resources/BuenMouse.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-					CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = NXT93S55FY;
-				ENABLE_HARDENED_RUNTIME = YES;
+					ARCHS = arm64;
+					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+					ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+					CODE_SIGN_ENTITLEMENTS = Resources/BuenMouse.entitlements;
+					COMBINE_HIDPI_IMAGES = YES;
+						CURRENT_PROJECT_VERSION = 2;
+					ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Resources/Info.plist;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Standard Swift project workflow tooling: shared formatting config, Makefile
+  checks, optional Lefthook hooks, public agent guide, and contributor/security
+  docs.
+
 ## [2.1.2] - 2026-05-29
 
 ### Changed
@@ -60,7 +66,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Menu bar app behavior: status bar toggle, dropdown menu, and accessory-style
   presentation without duplicate windows.
 
-## [1.1.2] - 2025-11-30
+## [1.1.2] - 2025-11-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Standard Swift project workflow tooling: shared formatting config, Makefile
   checks, optional Lefthook hooks, public agent guide, and contributor/security
   docs.
+- Stable local development signing via `SigningDefaults.xcconfig` /
+  `Signing.xcconfig.example` plus `make install-dev` for fast local reinstalls
+  without resetting macOS permission grants.
+
+### Changed
+
+- Moved local signing identity out of the tracked Xcode project and into the
+  ignored `Signing.xcconfig` override used for developer installs.
 
 ## [2.1.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [2.1.2] - 2026-05-29
+
+### Changed
+
+- Distribution-only patch: the macOS DMG is signed with Developer ID Application,
+  notarized, stapled, and validated for Gatekeeper. No app behavior changed.
+
+## [2.1.1] - 2026-05-15
+
+### Added
+
+- Drag-to-grant Accessibility onboarding: guided setup opens System Settings,
+  floats a helper card anchored to the Accessibility pane, and auto-dismisses
+  when permission is granted.
+- Refreshed About panel with monospace version/build, feature chips, separator,
+  auto-updating copyright year, and softer gradient background.
+
+### Fixed
+
+- Rebuilt the hosting view on every settings show so gesture carousel animations
+  stay fluid after closing and reopening the window.
+
+## [2.1.0] - 2026-05-14
+
+### Changed
+
+- Bumped version metadata and refreshed the About panel copy for the 2.1 line.
+
+## [2.0.0] - 2025-11-21
+
+### Added
+
+- Compact settings layout with interactive gesture showcase carousel.
+- Animated gesture previews for Mission Control, space navigation, scroll zoom,
+  and invert-scroll demos.
+- Separate About window and reordered onboarding slides.
+
+### Changed
+
+- Complete UI rewrite focused on the status-bar-first workflow and focused
+  settings surface.
+
+### Removed
+
+- Side mouse button (buttons 3/4) handling so back/forward use native macOS
+  behavior.
+
+## [1.2.0] - 2025-11-21
+
+### Changed
+
+- Menu bar app behavior: status bar toggle, dropdown menu, and accessory-style
+  presentation without duplicate windows.
+
+## [1.1.2] - 2025-11-30
+
+### Added
+
+- Native side-button support before later removal in 2.0.0.
+
+## [1.1.1] - 2025-10-02
+
+### Fixed
+
+- Critical stability fixes for gesture monitoring and window lifecycle edge cases.
+
+## [1.1.0] - 2025-10-02
+
+### Added
+
+- Granular controls for drag threshold, invert direction, scroll zoom, and
+  launch-at-login options.
+
+## [1.0.1] - 2025-08-23
+
+### Changed
+
+- Performance and UI polish for the initial public release line.
+
+## [1.0.0] - 2025-08-12
+
+### Added
+
+- First stable release: middle-click Mission Control, middle-click drag for
+  space navigation, Ctrl+scroll zoom, and natural scroll inversion for macOS.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for helping improve BuenMouse.
+
+## Setup
+
+```bash
+make tools
+make ci-check
+```
+
+Open `BuenMouse.xcodeproj` in Xcode and run the `BuenMouse` scheme.
+
+## Workflow
+
+```bash
+make format
+make lint
+make build
+```
+
+- Keep changes focused and small.
+- Do not commit credentials, logs, crash reports, DMGs, archives, local docs,
+  or signing files.
+- The project does not have a unit test target yet; `make ci-check` is the
+  current local gate (lint + Release build).
+- Follow the branch-and-review workflow in `AGENTS.md` before committing.
+
+## Pull Requests
+
+Before opening a PR:
+
+```bash
+make ci-check
+git diff --check
+```
+
+Include:
+
+- What changed.
+- How it was verified.
+- Any permission, signing, or accessibility impact.
+
+## Signing
+
+Contributor builds use the tracked project signing defaults. Maintainers
+configure Developer ID, notarization, and release DMG packaging outside routine
+development commits.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help tools format format-all lint lint-all build ci-check hooks-install
+.PHONY: help tools format format-all lint lint-all build release install-dev size-check ci-check release-check notarized-dmg hooks-install
 
 .DEFAULT_GOAL := help
 
@@ -7,6 +7,7 @@ SCHEME := BuenMouse
 SWIFT_FORMAT := xcrun swift-format
 SWIFT_FORMAT_CONFIG := .swift-format
 RELEASE_DERIVED_DATA := ./build_check
+RELEASE_APP := $(RELEASE_DERIVED_DATA)/Build/Products/Release/BuenMouse.app
 
 help:
 	@printf "BuenMouse developer commands\n\n"
@@ -16,7 +17,12 @@ help:
 	@printf "  make lint          Check changed Swift files without editing files\n"
 	@printf "  make lint-all      Check all Swift sources explicitly\n"
 	@printf "  make build         Build Release for Apple Silicon\n"
+	@printf "  make release       Build Release for Apple Silicon\n"
+	@printf "  make install-dev   Reinstall signed Release build to /Applications\n"
+	@printf "  make size-check    Measure the Release app bundle\n"
 	@printf "  make ci-check      Local gate: lint + Release build\n"
+	@printf "  make release-check Release gate: lint + Release build + size check\n"
+	@printf "  make notarized-dmg Build, sign, notarize, staple, and validate the release DMG\n"
 	@printf "  make hooks-install Install optional Lefthook git hooks\n"
 
 tools:
@@ -40,13 +46,30 @@ lint-all: tools
 		--configuration $(SWIFT_FORMAT_CONFIG) \
 		.
 
-build:
+build release:
 	xcodebuild -project $(PROJECT) -scheme $(SCHEME) \
 		-configuration Release -destination 'generic/platform=macOS' \
 		-derivedDataPath $(RELEASE_DERIVED_DATA) build
 
+install-dev:
+	@chmod +x scripts/install_dev.sh
+	@scripts/install_dev.sh
+
+size-check:
+	@test -d "$(RELEASE_APP)" || { echo "Release app not found. Run: make release"; exit 66; }
+	@du -sh "$(RELEASE_APP)" "$(RELEASE_APP)/Contents/MacOS/BuenMouse" "$(RELEASE_APP)/Contents/Resources"
+	@printf "archs: "
+	@lipo -archs "$(RELEASE_APP)/Contents/MacOS/BuenMouse"
+	@find "$(RELEASE_APP)" -maxdepth 4 -type f | sort
+
 ci-check: lint build
 	@printf "ci-check: passed\n"
+
+release-check: lint release size-check
+	@printf "release-check: passed\n"
+
+notarized-dmg:
+	@scripts/package_notarized_dmg.sh
 
 hooks-install:
 	@command -v lefthook >/dev/null || { echo "lefthook is not installed. Install it with: brew install lefthook"; exit 69; }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+.PHONY: help tools format format-all lint lint-all build ci-check hooks-install
+
+.DEFAULT_GOAL := help
+
+PROJECT := BuenMouse.xcodeproj
+SCHEME := BuenMouse
+SWIFT_FORMAT := xcrun swift-format
+SWIFT_FORMAT_CONFIG := .swift-format
+RELEASE_DERIVED_DATA := ./build_check
+
+help:
+	@printf "BuenMouse developer commands\n\n"
+	@printf "  make tools         Check required local tools\n"
+	@printf "  make format        Format changed Swift files with Xcode swift-format\n"
+	@printf "  make format-all    Format all Swift sources explicitly\n"
+	@printf "  make lint          Check changed Swift files without editing files\n"
+	@printf "  make lint-all      Check all Swift sources explicitly\n"
+	@printf "  make build         Build Release for Apple Silicon\n"
+	@printf "  make ci-check      Local gate: lint + Release build\n"
+	@printf "  make hooks-install Install optional Lefthook git hooks\n"
+
+tools:
+	@xcrun --find swift-format >/dev/null
+	@xcodebuild -version >/dev/null
+	@printf "tools: xcodebuild and swift-format are available\n"
+
+format: tools
+	@scripts/swift_format_changed.sh format
+
+format-all: tools
+	$(SWIFT_FORMAT) format --in-place --recursive --parallel \
+		--configuration $(SWIFT_FORMAT_CONFIG) \
+		.
+
+lint: tools
+	@scripts/swift_format_changed.sh lint
+
+lint-all: tools
+	$(SWIFT_FORMAT) lint --strict --recursive --parallel \
+		--configuration $(SWIFT_FORMAT_CONFIG) \
+		.
+
+build:
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) \
+		-configuration Release -destination 'generic/platform=macOS' \
+		-derivedDataPath $(RELEASE_DERIVED_DATA) build
+
+ci-check: lint build
+	@printf "ci-check: passed\n"
+
+hooks-install:
+	@command -v lefthook >/dev/null || { echo "lefthook is not installed. Install it with: brew install lefthook"; exit 69; }
+	lefthook install

--- a/README.md
+++ b/README.md
@@ -96,9 +96,18 @@ open BuenMouse.xcodeproj
 O desde terminal:
 
 ```bash
-xcodebuild -project BuenMouse.xcodeproj -scheme BuenMouse \
-  -configuration Release -derivedDataPath ./build build
+make ci-check
 ```
+
+Para iterar localmente en tu Mac:
+
+```bash
+make install-dev
+```
+
+`make install-dev` compila la app Release firmada localmente, la reinstala en
+`/Applications/BuenMouse.app` y la relanza sin resetear los permisos de macOS
+mientras `Signing.xcconfig` mantenga la misma identidad Apple Development.
 
 ### Requisitos
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security
+
+## Secret Handling
+
+Do not commit:
+
+- API keys, tokens, or `.env*` files
+- Signing certificates, provisioning profiles, notarization files, or private
+  Xcode configuration
+- Personal Apple Developer Team IDs, local Xcode user data, or machine-specific
+  paths
+- Private agent notes, local crash reports, DMGs, or archives
+
+BuenMouse uses Accessibility and Input Monitoring for gesture handling. Do not
+add cloud relay, telemetry endpoints, or credential storage without an explicit
+design and security review.
+
+## Reporting
+
+For security-sensitive issues, do not include private logs or local identifiers
+in public issues. Open a minimal report describing the affected area and share
+sensitive details only through a private maintainer-approved channel.
+
+## Public Repo Boundary
+
+The public repo should contain source code, app assets, shared Xcode metadata,
+build scripts, formatting config, README, changelog, contributing notes,
+security notes, and license. Local maintainer notes and release artifacts stay
+ignored unless they are scrubbed and intentionally published.

--- a/Signing.xcconfig.example
+++ b/Signing.xcconfig.example
@@ -1,0 +1,17 @@
+// BuenMouse local signing template.
+//
+// First-time setup:
+//
+//   cp Signing.xcconfig.example Signing.xcconfig
+//
+// Then set your Apple Developer Team ID below (Xcode -> Settings -> Accounts,
+// or developer.apple.com/account). Signing.xcconfig is git-ignored so the
+// team ID never lands in version control. Requires an "Apple Development"
+// certificate with its private key in the login keychain.
+//
+// Why: a stable signing identity keeps macOS TCC permission grants
+// (Accessibility, Input Monitoring) across reinstalls; the ad-hoc default
+// re-prompts after every rebuild.
+CODE_SIGN_IDENTITY = Apple Development
+CODE_SIGN_STYLE = Manual
+DEVELOPMENT_TEAM = YOUR_TEAM_ID

--- a/SigningDefaults.xcconfig
+++ b/SigningDefaults.xcconfig
@@ -1,0 +1,13 @@
+// BuenMouse signing defaults - ad-hoc, so a fresh clone builds with zero
+// setup ("Sign to Run Locally", TeamIdentifier not set).
+//
+// Ad-hoc binaries get a new code-signing hash on every build, so macOS TCC
+// ties Accessibility and Input Monitoring grants to that exact build and
+// re-prompts after every reinstall. For local development, create the
+// git-ignored Signing.xcconfig override (see Signing.xcconfig.example):
+// a stable certificate identity keeps the TCC grants across rebuilds.
+CODE_SIGN_IDENTITY = -
+CODE_SIGN_STYLE = Manual
+DEVELOPMENT_TEAM =
+
+#include? "Signing.xcconfig"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: false
+  commands:
+    format:
+      glob: '*.swift'
+      run: scripts/swift_format_changed.sh format {staged_files}
+      stage_fixed: true
+
+    lint:
+      glob: '*.swift'
+      run: scripts/swift_format_changed.sh lint {staged_files}
+      fail_text: |
+        Swift format/lint failed. Run:
+          make format
+          make lint

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Rebuild and reinstall the locally signed Release app to /Applications.
+# Uses the same Apple Development identity from Signing.xcconfig so macOS
+# keeps Accessibility and Input Monitoring grants across fast UI iterations.
+# Do not use this over a notarized production install.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_SRC="$ROOT/build_check/Build/Products/Release/BuenMouse.app"
+APP_DST="/Applications/BuenMouse.app"
+
+cd "$ROOT"
+make release
+
+if [[ ! -d "$APP_SRC" ]]; then
+  echo "install-dev: expected app bundle at $APP_SRC" >&2
+  exit 1
+fi
+
+SIGNING_DETAILS="$(codesign -dvvv "$APP_SRC" 2>&1 || true)"
+if ! grep -q "Authority=Apple Development" <<<"$SIGNING_DETAILS"; then
+  echo "install-dev: Release app is not signed with Apple Development." >&2
+  echo "install-dev: copy Signing.xcconfig.example to Signing.xcconfig and set DEVELOPMENT_TEAM." >&2
+  exit 65
+fi
+if ! grep -q "^TeamIdentifier=" <<<"$SIGNING_DETAILS"; then
+  echo "install-dev: Release app has no TeamIdentifier; refusing to replace a TCC-granted install." >&2
+  exit 65
+fi
+
+osascript -e 'tell application "BuenMouse" to quit' 2>/dev/null || true
+sleep 1
+if pgrep -x BuenMouse >/dev/null 2>&1; then
+  killall BuenMouse 2>/dev/null || true
+  sleep 1
+fi
+
+ditto "$APP_SRC" "$APP_DST"
+open "$APP_DST"
+
+CDHASH="$(codesign -dvvv "$APP_DST" 2>&1 | sed -n 's/^CDHash=//p' | head -1)"
+echo "install-dev: installed CDHash=${CDHASH:-unknown} to $APP_DST"

--- a/scripts/swift_format_changed.sh
+++ b/scripts/swift_format_changed.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/swift_format_changed.sh format [file.swift ...]
+  scripts/swift_format_changed.sh lint [file.swift ...]
+
+Without explicit files, checks Swift files changed from HEAD plus untracked Swift files.
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 64
+fi
+
+mode="$1"
+shift
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+config=".swift-format"
+
+if [[ ! -f "$config" ]]; then
+  echo "Missing $config" >&2
+  exit 66
+fi
+
+if ! xcrun --find swift-format >/dev/null 2>&1; then
+  echo "swift-format not found. Install/use Xcode's command line tools." >&2
+  exit 69
+fi
+
+files=()
+
+if [[ $# -gt 0 ]]; then
+  for file in "$@"; do
+    [[ "$file" == *.swift && -f "$file" ]] && files+=("$file")
+  done
+else
+  while IFS= read -r file; do
+    [[ -n "$file" && -f "$file" ]] && files+=("$file")
+  done < <(
+    {
+      git diff --name-only --diff-filter=ACMR -- '*.swift'
+      git diff --cached --name-only --diff-filter=ACMR -- '*.swift'
+      git ls-files --others --exclude-standard -- '*.swift'
+    } | sort -u
+  )
+fi
+
+if [[ "${#files[@]}" -eq 0 ]]; then
+  echo "swift-format: no changed Swift files"
+  exit 0
+fi
+
+case "$mode" in
+  format)
+    xcrun swift-format format --in-place --configuration "$config" "${files[@]}"
+    ;;
+  lint)
+    xcrun swift-format lint --strict --configuration "$config" "${files[@]}"
+    ;;
+  *)
+    usage >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
Summary: standardize the local macOS dev install workflow around Apple Development signed builds; update compact docs and changelog notes; no production notarized release changes. Verification: local gates passed where applicable, make install-dev installed the dev build on this Mac, and post-install codesign/arm64/running checks passed.