### PR TITLE
feat: one-click in-app updates via Sparkle 2

### DIFF
--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -19,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupComponents()
         setupMenuBar()
         configureLaunchAtLoginDefault()
+        UpdateManager.shared.start()
 
         settingsManager.onMonitoringChanged = { [weak self] in
             self?.applyMonitoringState()

--- a/BuenMouse.xcodeproj/project.pbxproj
+++ b/BuenMouse.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		B0814B5C2E14B64400112727 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0814B582E14B64400112727 /* AppDelegate.swift */; };
 		B0814B5D2E14B64400112727 /* BuenMouseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0814B592E14B64400112727 /* BuenMouseApp.swift */; };
 		B0814B5E2E14B64400112727 /* ServiceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0814B5A2E14B64400112727 /* ServiceManager.swift */; };
+		B05A121E2F070001000000A3 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B05A121E2F070001000000A4 /* Sparkle */; };
 /* End PBXBuildFile section */
 
 	/* Begin PBXFileReference section */
@@ -56,6 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B05A121E2F070001000000A3 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,6 +108,7 @@
 			);
 			name = BuenMouse;
 			packageProductDependencies = (
+				B05A121E2F070001000000A4 /* Sparkle */,
 			);
 			productName = BuenMouse;
 			productReference = B06242CF2E0241D00061FE50 /* BuenMouse.app */;
@@ -136,6 +139,9 @@
 			);
 			mainGroup = B06242C62E0241D00061FE50;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				B05A121E2F070001000000B2 /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = B06242D02E0241D00061FE50 /* Products */;
 			projectDirPath = "";
@@ -298,7 +304,7 @@
 					ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 					CODE_SIGN_ENTITLEMENTS = Resources/BuenMouse.entitlements;
 					COMBINE_HIDPI_IMAGES = YES;
-						CURRENT_PROJECT_VERSION = 4;
+						CURRENT_PROJECT_VERSION = 5;
 					ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -310,7 +316,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-					MARKETING_VERSION = 3.1.0;
+					MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = oliverio23.BuenMouse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -327,7 +333,7 @@
 					ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 					CODE_SIGN_ENTITLEMENTS = Resources/BuenMouse.entitlements;
 					COMBINE_HIDPI_IMAGES = YES;
-						CURRENT_PROJECT_VERSION = 4;
+						CURRENT_PROJECT_VERSION = 5;
 					ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -339,7 +345,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-					MARKETING_VERSION = 3.1.0;
+					MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = oliverio23.BuenMouse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -370,6 +376,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B05A121E2F070001000000B2 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.9.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B05A121E2F070001000000A4 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B05A121E2F070001000000B2 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B06242C72E0241D00061FE50 /* Project object */;
 }

--- a/BuenMouse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BuenMouse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e721da7f9826abdffcb6185e886155efa2514bd6234475f1afa893e29eb258d6",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-07-11
+
+### Added
+
+- One-click in-app updates via Sparkle 2. A quiet daily check against GitHub
+  Releases surfaces new versions as a row in the menu bar panel and a capsule
+  in the About window; one click downloads, installs, and relaunches the app.
+  Updates are EdDSA-signed and verified against the public key embedded in
+  the app. The automatic check can be disabled in Settings, and the About
+  window offers a manual "Check for updates". Scheduled check failures stay
+  silent; nothing is ever sent to any server.
+
 ## [3.1.0] - 2026-07-01
 
 ### Added

--- a/Core/Updates/UpdateManager.swift
+++ b/Core/Updates/UpdateManager.swift
@@ -1,0 +1,326 @@
+import AppKit
+import Combine
+import Foundation
+import Sparkle
+import os
+
+/// In-app updates via Sparkle. The scheduled daily check only surfaces a
+/// pending update (menu row + About capsule); downloading, installing, and
+/// relaunching happen when the user clicks Install, with progress mirrored
+/// in `phase`. Scheduled-check failures stay silent; only a user-requested
+/// install surfaces errors.
+@MainActor
+final class UpdateManager: ObservableObject {
+
+    static let shared = UpdateManager()
+
+    enum Phase: Equatable {
+        case idle
+        case available(version: String)
+        /// nil fraction = size unknown yet (indeterminate spinner).
+        case downloading(fraction: Double?)
+        case installing
+        case failed(version: String)
+    }
+
+    enum ManualCheckStatus: Equatable {
+        case idle
+        case checking
+        case upToDate
+    }
+
+    static let autoCheckDefaultsKey = "autoUpdateCheckEnabled"
+    /// Local appcast testing only:
+    /// `defaults write oliverio23.BuenMouse updateFeedURLOverride <url>`.
+    static let feedURLOverrideDefaultsKey = "updateFeedURLOverride"
+
+    @Published private(set) var phase: Phase = .idle
+    /// GitHub release page of the pending update (the appcast item's <link>).
+    @Published private(set) var releasePageURL: URL?
+    /// Ephemeral "you're up to date" feedback for the About window.
+    @Published private(set) var manualCheckStatus: ManualCheckStatus = .idle
+    @Published private(set) var autoCheckEnabled: Bool
+
+    private let log = Logger(subsystem: "oliverio23.BuenMouse", category: "updates")
+
+    private var updater: SPUUpdater?
+    private var driver: Driver?
+    private var updaterDelegate: UpdaterDelegate?
+
+    private var installRequested = false
+    private var pendingVersion: String?
+    private var pendingIsInformationOnly = false
+    private var expectedDownloadBytes: UInt64 = 0
+    private var receivedDownloadBytes: UInt64 = 0
+    private var manualCheckPending = false
+    private var manualCheckResetTask: Task<Void, Never>?
+
+    init() {
+        // Defaults to enabled until the Settings toggle writes the key.
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: Self.autoCheckDefaultsKey) == nil {
+            autoCheckEnabled = true
+        } else {
+            autoCheckEnabled = defaults.bool(forKey: Self.autoCheckDefaultsKey)
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard updater == nil else { return }
+
+        let driver = Driver(manager: self)
+        let updaterDelegate = UpdaterDelegate()
+        let updater = SPUUpdater(
+            hostBundle: .main,
+            applicationBundle: .main,
+            userDriver: driver,
+            delegate: updaterDelegate
+        )
+        updater.automaticallyDownloadsUpdates = false
+        updater.automaticallyChecksForUpdates = autoCheckEnabled
+
+        do {
+            try updater.start()
+        } catch {
+            log.error("Updater failed to start: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        self.driver = driver
+        self.updaterDelegate = updaterDelegate
+        self.updater = updater
+    }
+
+    func setAutoCheckEnabled(_ enabled: Bool) {
+        autoCheckEnabled = enabled
+        UserDefaults.standard.set(enabled, forKey: Self.autoCheckDefaultsKey)
+        updater?.automaticallyChecksForUpdates = enabled
+    }
+
+    // MARK: - User actions
+
+    /// Menu row / About capsule click: download + install + relaunch, or
+    /// retry after a failure. Information-only updates open the release page.
+    func installPendingUpdate() {
+        guard let updater else { return }
+        if pendingIsInformationOnly {
+            openReleasePage()
+            return
+        }
+        guard updater.sessionInProgress == false else { return }
+        installRequested = true
+        phase = .downloading(fraction: nil)
+        updater.checkForUpdates()
+    }
+
+    /// About window: explicit re-check with visible "up to date" feedback.
+    func checkForUpdatesManually() {
+        guard let updater, updater.sessionInProgress == false else { return }
+        manualCheckResetTask?.cancel()
+        manualCheckPending = true
+        manualCheckStatus = .checking
+        updater.checkForUpdates()
+    }
+
+    func openReleasePage() {
+        guard let releasePageURL else { return }
+        NSWorkspace.shared.open(releasePageURL)
+    }
+
+    // MARK: - Driver events (pure state transitions, unit-testable)
+
+    func handleUpdateFound(
+        version: String,
+        releasePage: URL?,
+        informationOnly: Bool
+    ) -> SPUUserUpdateChoice {
+        pendingVersion = version
+        pendingIsInformationOnly = informationOnly
+        releasePageURL = releasePage
+        finishManualCheck(status: .idle)
+
+        if installRequested && !informationOnly {
+            return .install
+        }
+        installRequested = false
+        phase = .available(version: version)
+        return .dismiss
+    }
+
+    func handleDownloadInitiated() {
+        expectedDownloadBytes = 0
+        receivedDownloadBytes = 0
+        phase = .downloading(fraction: nil)
+    }
+
+    func handleDownloadExpectedLength(_ length: UInt64) {
+        expectedDownloadBytes = length
+    }
+
+    func handleDownloadReceived(bytes: UInt64) {
+        receivedDownloadBytes += bytes
+        guard expectedDownloadBytes > 0 else { return }
+        let fraction = min(1.0, Double(receivedDownloadBytes) / Double(expectedDownloadBytes))
+        phase = .downloading(fraction: fraction)
+    }
+
+    func handleExtractionStarted() {
+        phase = .installing
+    }
+
+    func handleReadyToInstall() -> SPUUserUpdateChoice {
+        phase = .installing
+        return .install
+    }
+
+    func handleInstalling() {
+        phase = .installing
+    }
+
+    func handleNotFound() {
+        installRequested = false
+        pendingVersion = nil
+        pendingIsInformationOnly = false
+        releasePageURL = nil
+        phase = .idle
+        finishManualCheck(status: .upToDate)
+    }
+
+    /// Scheduled-check errors stay silent; a user-requested install shows
+    /// a retryable failure row instead.
+    func handleError(_ message: String) {
+        finishManualCheck(status: .idle)
+        if installRequested, let pendingVersion {
+            log.error("Update install failed: \(message, privacy: .public)")
+            phase = .failed(version: pendingVersion)
+        } else {
+            log.debug("Update check failed silently")
+            phase = pendingVersion.map { .available(version: $0) } ?? .idle
+        }
+        installRequested = false
+    }
+
+    /// Sparkle tears the session down (abort or completion). Keep the
+    /// pending row alive; only roll back an in-flight progress state.
+    func handleDismissInstallation() {
+        switch phase {
+        case .downloading, .installing:
+            phase = pendingVersion.map { .available(version: $0) } ?? .idle
+        case .idle, .available, .failed:
+            break
+        }
+    }
+
+    private func finishManualCheck(status: ManualCheckStatus) {
+        guard manualCheckPending else { return }
+        manualCheckPending = false
+        manualCheckStatus = status
+        guard status != .idle else { return }
+        manualCheckResetTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+            self?.manualCheckStatus = .idle
+        }
+    }
+}
+
+// MARK: - Sparkle user driver
+
+/// Bridges Sparkle's user-interaction callbacks onto the manager's phase.
+/// Every callback arrives on the main actor (the protocol is NS_SWIFT_UI_ACTOR).
+@MainActor
+private final class Driver: NSObject, SPUUserDriver {
+
+    private unowned let manager: UpdateManager
+
+    init(manager: UpdateManager) {
+        self.manager = manager
+    }
+
+    func show(
+        _ request: SPUUpdatePermissionRequest,
+        reply: @escaping (SUUpdatePermissionResponse) -> Void
+    ) {
+        // Unreached: SUEnableAutomaticChecks in Info.plist suppresses the prompt.
+        reply(SUUpdatePermissionResponse(automaticUpdateChecks: true, sendSystemProfile: false))
+    }
+
+    func showUserInitiatedUpdateCheck(cancellation: @escaping () -> Void) {}
+
+    func showUpdateFound(
+        with appcastItem: SUAppcastItem,
+        state: SPUUserUpdateState,
+        reply: @escaping (SPUUserUpdateChoice) -> Void
+    ) {
+        let choice = manager.handleUpdateFound(
+            version: appcastItem.displayVersionString,
+            releasePage: appcastItem.infoURL,
+            informationOnly: appcastItem.isInformationOnlyUpdate
+        )
+        reply(choice)
+    }
+
+    func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {}
+
+    func showUpdateReleaseNotesFailedToDownloadWithError(_ error: any Error) {}
+
+    func showUpdateNotFoundWithError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        manager.handleNotFound()
+        acknowledgement()
+    }
+
+    func showUpdaterError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        manager.handleError(error.localizedDescription)
+        acknowledgement()
+    }
+
+    func showDownloadInitiated(cancellation: @escaping () -> Void) {
+        manager.handleDownloadInitiated()
+    }
+
+    func showDownloadDidReceiveExpectedContentLength(_ expectedContentLength: UInt64) {
+        manager.handleDownloadExpectedLength(expectedContentLength)
+    }
+
+    func showDownloadDidReceiveData(ofLength length: UInt64) {
+        manager.handleDownloadReceived(bytes: length)
+    }
+
+    func showDownloadDidStartExtractingUpdate() {
+        manager.handleExtractionStarted()
+    }
+
+    func showExtractionReceivedProgress(_ progress: Double) {}
+
+    func showReady(toInstallAndRelaunch reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        reply(manager.handleReadyToInstall())
+    }
+
+    func showInstallingUpdate(
+        withApplicationTerminated applicationTerminated: Bool,
+        retryTerminatingApplication: @escaping () -> Void
+    ) {
+        manager.handleInstalling()
+    }
+
+    func showUpdateInstalledAndRelaunched(_ relaunched: Bool, acknowledgement: @escaping () -> Void) {
+        acknowledgement()
+    }
+
+    func dismissUpdateInstallation() {
+        manager.handleDismissInstallation()
+    }
+}
+
+// MARK: - Sparkle updater delegate
+
+private final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+
+    /// Local-testing escape hatch: point the feed at a local appcast.
+    /// Production resolves SUFeedURL from Info.plist (return nil).
+    nonisolated func feedURLString(for updater: SPUUpdater) -> String? {
+        UserDefaults.standard.string(forKey: UpdateManager.feedURLOverrideDefaultsKey)
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help tools format format-all lint lint-all build release install-dev size-check ci-check release-check notarized-dmg hooks-install
+.PHONY: help tools format format-all lint lint-all build release install-dev size-check ci-check release-check notarized-dmg appcast hooks-install
 
 .DEFAULT_GOAL := help
 
@@ -23,6 +23,7 @@ help:
 	@printf "  make ci-check      Local gate: lint + Release build\n"
 	@printf "  make release-check Release gate: lint + Release build + size check\n"
 	@printf "  make notarized-dmg Build, sign, notarize, staple, and validate the release DMG\n"
+	@printf "  make appcast       Zip the notarized app, EdDSA-sign it, and write appcast.xml\n"
 	@printf "  make hooks-install Install optional Lefthook git hooks\n"
 
 tools:
@@ -70,6 +71,10 @@ release-check: lint release size-check
 
 notarized-dmg:
 	@scripts/package_notarized_dmg.sh
+
+appcast:
+	@chmod +x scripts/generate_appcast.sh
+	@scripts/generate_appcast.sh
 
 hooks-install:
 	@command -v lefthook >/dev/null || { echo "lefthook is not installed. Install it with: brew install lefthook"; exit 69; }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Cada gesto se puede activar o desactivar independientemente desde la ventana pri
 3. Abre BuenMouse desde Aplicaciones
 4. macOS te pedirá permisos de **Accesibilidad** — actívalos para que los gestos funcionen
 
+Después de la primera instalación no necesitas volver a descargar nada: BuenMouse
+revisa GitHub Releases una vez al día y, cuando hay una versión nueva, aparece una
+fila en el panel de la barra de menú — un clic la descarga, instala y relanza la
+app (actualizaciones firmadas con EdDSA vía Sparkle). Se puede desactivar en Ajustes.
+
 ### Otorgar permisos de Accesibilidad
 
 BuenMouse necesita permisos de accesibilidad para detectar los clicks y scrolls del mouse. La primera vez que la abras:
@@ -80,6 +85,8 @@ La apariencia sigue automáticamente el tema del sistema (claro / oscuro).
 - 💻 **Todo es local** — los gestos se procesan en tu Mac
 - 🔓 **Código abierto** — puedes auditar exactamente qué hace
 - 🔐 **Permisos mínimos** — solo Accesibilidad y Apple Events (para abrir Mission Control)
+- 🔄 **Única conexión de red**: la búsqueda de actualizaciones (una vez al día, opcional)
+  descarga el `appcast.xml` firmado desde GitHub Releases; no envía ningún dato
 
 ---
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -8,5 +8,13 @@
     <string>BuenMouse necesita permiso para controlar otras aplicaciones del sistema, como System Events y Mission Control.</string>
     <key>LSUIElement</key>
     <true/>
+    <!-- Sparkle in-app updates: public feed + EdDSA public key (private key
+         lives in the maintainer's Keychain; never in the repo). -->
+    <key>SUFeedURL</key>
+    <string>https://github.com/StevenACZ/BuenMouse/releases/latest/download/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>EjJwYzuWlNuccLSqIcVxHRlGMLg7R6ONwpUjnVbFqY8=</string>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
 </dict>
 </plist>

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -95,3 +95,21 @@
 /* Status item */
 "statusitem.active" = "BuenMouse — Active";
 "statusitem.paused" = "BuenMouse — Paused";
+
+/* In-app updates (Sparkle) */
+"menubar.update.available" = "Update available";
+"menubar.update.install_hint" = "v%@ — click to install";
+"menubar.update.downloading" = "Downloading update…";
+"menubar.update.installing" = "Installing update…";
+"menubar.update.relaunch" = "BuenMouse will relaunch by itself";
+"menubar.update.failed" = "Update failed";
+"menubar.update.retry_hint" = "Click to try again";
+"about.update.install" = "Install v%@";
+"about.update.downloading" = "Downloading…";
+"about.update.installing" = "Installing…";
+"about.update.retry" = "Update failed — try again";
+"about.update.release_notes" = "View release notes";
+"about.update.check" = "Check for updates";
+"about.update.up_to_date" = "You're up to date";
+"settings.updates.title" = "Check for updates automatically";
+"settings.updates.subtitle" = "Checks GitHub Releases once a day. Nothing is sent.";

--- a/Resources/es.lproj/Localizable.strings
+++ b/Resources/es.lproj/Localizable.strings
@@ -95,3 +95,21 @@
 /* Status item */
 "statusitem.active" = "BuenMouse — Activo";
 "statusitem.paused" = "BuenMouse — En pausa";
+
+/* In-app updates (Sparkle) */
+"menubar.update.available" = "Actualización disponible";
+"menubar.update.install_hint" = "v%@ — clic para instalar";
+"menubar.update.downloading" = "Descargando actualización…";
+"menubar.update.installing" = "Instalando actualización…";
+"menubar.update.relaunch" = "BuenMouse se relanzará solo";
+"menubar.update.failed" = "La actualización falló";
+"menubar.update.retry_hint" = "Clic para reintentar";
+"about.update.install" = "Instalar v%@";
+"about.update.downloading" = "Descargando…";
+"about.update.installing" = "Instalando…";
+"about.update.retry" = "Falló la actualización — reintentar";
+"about.update.release_notes" = "Ver notas de la versión";
+"about.update.check" = "Buscar actualizaciones";
+"about.update.up_to_date" = "Estás al día";
+"settings.updates.title" = "Buscar actualizaciones automáticamente";
+"settings.updates.subtitle" = "Consulta GitHub Releases una vez al día. No se envía nada.";

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,14 @@ gesture handling. Do not
 add cloud relay, telemetry endpoints, or credential storage without an explicit
 design and security review.
 
+## Update Channel
+
+In-app updates are served from GitHub Releases through a Sparkle appcast
+(`appcast.xml` uploaded with each release). Updates install only if their
+EdDSA signature matches the public key embedded in the app's Info.plist, so
+only the maintainer holding the private key (stored in the maintainer's
+Keychain, never in the repo) can publish an installable update.
+
 ## Reporting
 
 For security-sensitive issues, do not include private logs or local identifiers

--- a/Views/About/AboutView.swift
+++ b/Views/About/AboutView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// on the gesture showcase.
 struct AboutView: View {
     @ObservedObject private var localizationManager = LocalizationManager.shared
+    @ObservedObject private var updateManager = UpdateManager.shared
 
     private var version: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "3.0.0"
@@ -63,8 +64,127 @@ struct AboutView: View {
                         .font(.system(size: 11, weight: .medium, design: .monospaced))
                         .foregroundStyle(.tertiary)
                 }
+
+                updateStatus
+                    .padding(.top, 4)
             }
         }
+    }
+
+    /// Update capsule mirroring `UpdateManager.phase`, plus a manual
+    /// "check for updates" affordance when nothing is pending.
+    @ViewBuilder
+    private var updateStatus: some View {
+        switch updateManager.phase {
+        case .idle:
+            checkForUpdatesButton
+
+        case .available(let version):
+            VStack(spacing: 5) {
+                Button {
+                    updateManager.installPendingUpdate()
+                } label: {
+                    updateCapsule(
+                        icon: "arrow.down.circle",
+                        text: "about.update.install".localized(version)
+                    )
+                }
+                .buttonStyle(.plain)
+
+                if updateManager.releasePageURL != nil {
+                    Button {
+                        updateManager.openReleasePage()
+                    } label: {
+                        Text("about.update.release_notes".localized)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .underline()
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+        case .downloading(let fraction):
+            updateProgressCapsule(
+                text: "about.update.downloading".localized
+                    + (fraction.map { " \(Int($0 * 100))%" } ?? ""))
+
+        case .installing:
+            updateProgressCapsule(text: "about.update.installing".localized)
+
+        case .failed:
+            Button {
+                updateManager.installPendingUpdate()
+            } label: {
+                updateCapsule(
+                    icon: "exclamationmark.arrow.circlepath",
+                    text: "about.update.retry".localized
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private var checkForUpdatesButton: some View {
+        switch updateManager.manualCheckStatus {
+        case .checking:
+            HStack(spacing: 5) {
+                ProgressView()
+                    .controlSize(.mini)
+                Text("about.update.check".localized)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        case .upToDate:
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.circle")
+                    .font(.caption2)
+                Text("about.update.up_to_date".localized)
+                    .font(.caption2.weight(.medium))
+            }
+            .foregroundStyle(accent)
+        case .idle:
+            Button {
+                updateManager.checkForUpdatesManually()
+            } label: {
+                Text("about.update.check".localized)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .underline()
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func updateCapsule(icon: String, text: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon)
+                .font(.caption2)
+
+            Text(text)
+                .font(.caption2.weight(.medium))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(Capsule().fill(accent.opacity(0.12)))
+        .overlay(Capsule().strokeBorder(accent.opacity(0.22), lineWidth: 1))
+        .foregroundStyle(accent)
+    }
+
+    private func updateProgressCapsule(text: String) -> some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.mini)
+
+            Text(text)
+                .font(.caption2.weight(.medium))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(Capsule().fill(accent.opacity(0.12)))
+        .overlay(Capsule().strokeBorder(accent.opacity(0.22), lineWidth: 1))
+        .foregroundStyle(accent)
     }
 
     private var taglineSection: some View {

--- a/Views/MenuBar/MenuBarRows.swift
+++ b/Views/MenuBar/MenuBarRows.swift
@@ -48,6 +48,89 @@ struct ActionRow: View {
     }
 }
 
+/// Update lifecycle row: pending update → one-click install with inline
+/// download/install progress; a failed install offers a retry.
+struct UpdateMenuRow: View {
+    @ObservedObject var manager: UpdateManager
+
+    var body: some View {
+        switch manager.phase {
+        case .idle:
+            EmptyView()
+
+        case .available(let version):
+            ActionRow(
+                icon: "arrow.down.circle",
+                title: "menubar.update.available".localized,
+                subtitle: "menubar.update.install_hint".localized(version)
+            ) {
+                manager.installPendingUpdate()
+            }
+
+        case .downloading(let fraction):
+            UpdateProgressRow(
+                title: "menubar.update.downloading".localized,
+                subtitle: fraction.map { "\(Int($0 * 100))%" },
+                fraction: fraction
+            )
+
+        case .installing:
+            UpdateProgressRow(
+                title: "menubar.update.installing".localized,
+                subtitle: "menubar.update.relaunch".localized,
+                fraction: nil
+            )
+
+        case .failed:
+            ActionRow(
+                icon: "exclamationmark.arrow.circlepath",
+                title: "menubar.update.failed".localized,
+                subtitle: "menubar.update.retry_hint".localized
+            ) {
+                manager.installPendingUpdate()
+            }
+        }
+    }
+}
+
+/// Non-interactive progress row shown while an update downloads or installs.
+struct UpdateProgressRow: View {
+    let title: String
+    let subtitle: String?
+    let fraction: Double?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Group {
+                if let fraction {
+                    ProgressView(value: fraction)
+                        .progressViewStyle(.circular)
+                } else {
+                    ProgressView()
+                }
+            }
+            .controlSize(.small)
+            .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.primary)
+
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+}
+
 /// Warning banner shown while Accessibility access is missing.
 struct PermissionBanner: View {
     let action: () -> Void

--- a/Views/MenuBar/MenuBarView.swift
+++ b/Views/MenuBar/MenuBarView.swift
@@ -29,6 +29,7 @@ struct MenuBarPanelHost: View {
 struct MenuBarView<Settings: SettingsProtocol>: View {
     @ObservedObject var settings: Settings
     @ObservedObject private var localizationManager = LocalizationManager.shared
+    @ObservedObject private var updateManager = UpdateManager.shared
     let isPermissionGranted: Bool
     let openSettings: () -> Void
     let openAbout: () -> Void
@@ -54,6 +55,12 @@ struct MenuBarView<Settings: SettingsProtocol>: View {
 
             Divider()
                 .padding(.horizontal, 12)
+
+            if updateManager.phase != .idle {
+                UpdateMenuRow(manager: updateManager)
+
+                Divider().padding(.horizontal, 16)
+            }
 
             ActionRow(
                 icon: "gearshape",

--- a/Views/Settings/SettingsView.swift
+++ b/Views/Settings/SettingsView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct SettingsView<Settings: SettingsProtocol>: View {
     @ObservedObject var settings: Settings
     @ObservedObject private var localizationManager = LocalizationManager.shared
+    @ObservedObject private var updateManager = UpdateManager.shared
 
     @State private var currentSlide: GesturePreviewType = .missionControl
     @State private var showResetConfirmation = false
@@ -136,6 +137,26 @@ struct SettingsView<Settings: SettingsProtocol>: View {
                 .controlSize(.small)
                 .labelsHidden()
                 .fixedSize()
+            }
+
+            Divider().padding(.horizontal, 14)
+
+            settingRow(
+                icon: "arrow.down.circle",
+                title: "settings.updates.title".localized,
+                subtitle: "settings.updates.subtitle".localized
+            ) {
+                Toggle(
+                    "",
+                    isOn: Binding(
+                        get: { updateManager.autoCheckEnabled },
+                        set: { updateManager.setAutoCheckEnabled($0) }
+                    )
+                )
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .labelsHidden()
+                .tint(Theme.accent)
             }
 
             Divider().padding(.horizontal, 14)

--- a/scripts/generate_appcast.sh
+++ b/scripts/generate_appcast.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Build the Sparkle update artifacts for a release: a ZIP of the (already
+# notarized) app plus an appcast.xml whose enclosure is EdDSA-signed with the
+# private key stored in the login Keychain (created once via generate_keys).
+#
+# Upload BOTH files as assets of the GitHub release. The app resolves the feed
+# through the stable URL:
+#   https://github.com/StevenACZ/BuenMouse/releases/latest/download/appcast.xml
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+APP_PATH="${APP_PATH:-build/notarized-release/Build/Products/Release/BuenMouse.app}"
+OUTPUT_DIR="${OUTPUT_DIR:-$HOME/Downloads}"
+REPO_URL="https://github.com/StevenACZ/BuenMouse"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "App bundle not found: $APP_PATH" >&2
+  echo "Run 'make notarized-dmg' first, or set APP_PATH." >&2
+  exit 65
+fi
+
+SPARKLE_BIN="$(ls -d build/*/SourcePackages/artifacts/sparkle/Sparkle/bin 2>/dev/null | head -1)"
+if [[ -z "$SPARKLE_BIN" ]]; then
+  echo "Sparkle tools not found under build/*/SourcePackages." >&2
+  echo "Build the project once so SwiftPM downloads the Sparkle artifact." >&2
+  exit 69
+fi
+
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
+BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"
+MIN_OS="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$INFO_PLIST")"
+
+ZIP_NAME="BuenMouse-v$VERSION.zip"
+ZIP_PATH="$OUTPUT_DIR/$ZIP_NAME"
+APPCAST_PATH="$OUTPUT_DIR/appcast.xml"
+
+echo "==> Zipping $APP_PATH -> $ZIP_PATH"
+rm -f "$ZIP_PATH"
+ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+
+echo "==> Signing update (EdDSA key from the login Keychain)"
+SIGNATURE_ATTRS="$("$SPARKLE_BIN/sign_update" "$ZIP_PATH")"
+# sign_update prints: sparkle:edSignature="..." length="..."
+
+PUB_DATE="$(LC_ALL=C date -u +"%a, %d %b %Y %H:%M:%S +0000")"
+
+echo "==> Writing $APPCAST_PATH"
+cat >"$APPCAST_PATH" <<APPCAST
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>BuenMouse</title>
+    <item>
+      <title>$VERSION</title>
+      <link>$REPO_URL/releases/tag/v$VERSION</link>
+      <sparkle:version>$BUILD</sparkle:version>
+      <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>$MIN_OS</sparkle:minimumSystemVersion>
+      <pubDate>$PUB_DATE</pubDate>
+      <enclosure
+        url="$REPO_URL/releases/download/v$VERSION/$ZIP_NAME"
+        type="application/octet-stream"
+        $SIGNATURE_ATTRS />
+    </item>
+  </channel>
+</rss>
+APPCAST
+
+echo "==> Done"
+echo "    $ZIP_PATH"
+echo "    $APPCAST_PATH"
+echo "Upload both as assets of the v$VERSION GitHub release."

--- a/scripts/package_notarized_dmg.sh
+++ b/scripts/package_notarized_dmg.sh
@@ -103,6 +103,27 @@ if [[ -z "$OUTPUT_DMG" ]]; then
   OUTPUT_DMG="$HOME/Downloads/BuenMouse-v$VERSION.dmg"
 fi
 
+SPARKLE_FW="$BUILT_APP/Contents/Frameworks/Sparkle.framework"
+if [[ -d "$SPARKLE_FW" ]]; then
+  # xcodebuild with manual signing does not deep-re-sign the executables
+  # nested inside Sparkle's prebuilt xcframework; Apple notarization rejects
+  # their upstream signatures (no Developer ID, no secure timestamp).
+  # Re-sign inside-out per Sparkle's distribution guidance, preserving the
+  # XPC services' own entitlements, then re-seal the framework and the app.
+  echo "==> Re-signing Sparkle nested executables with $SIGN_IDENTITY"
+  for NESTED in \
+    "$SPARKLE_FW/Versions/B/XPCServices/Downloader.xpc" \
+    "$SPARKLE_FW/Versions/B/XPCServices/Installer.xpc" \
+    "$SPARKLE_FW/Versions/B/Updater.app" \
+    "$SPARKLE_FW/Versions/B/Autoupdate"; do
+    codesign -f -o runtime --timestamp --preserve-metadata=entitlements \
+      -s "$SIGN_IDENTITY" "$NESTED"
+  done
+  codesign -f -o runtime --timestamp -s "$SIGN_IDENTITY" "$SPARKLE_FW"
+  codesign -f -o runtime --timestamp --preserve-metadata=entitlements \
+    -s "$SIGN_IDENTITY" "$BUILT_APP"
+fi
+
 echo "==> Verifying app signature"
 codesign --verify --deep --strict --verbose=2 "$BUILT_APP"
 SIGNING_DETAILS="$(codesign -dvv "$BUILT_APP" 2>&1)"


### PR DESCRIPTION
## Summary

- Adds the standard one-click in-app update channel (Sparkle 2, custom inline UI — no Sparkle windows and no in-app What's New, per the repo guardrail; release notes stay on GitHub Releases behind a link in About): a quiet daily check against GitHub Releases surfaces new versions as a row in the menu bar panel; one click downloads, installs, and relaunches.
- Updates are EdDSA-signed; the app verifies them against the public key embedded in Info.plist. Only releases signed with the maintainer's private key (login Keychain, never in the repo) can install.
- Sparkle 2.9.4+ wired as the project's first SwiftPM dependency (pbxproj scaffolding created from scratch).
- Packaging now re-signs Sparkle's nested executables (Downloader.xpc, Installer.xpc, Updater.app, Autoupdate) before notarization.
- New `scripts/generate_appcast.sh` + `make appcast`; every release now uploads DMG + signed ZIP + `appcast.xml`.
- Version 3.2.0 (build 5), changelog cut, README privacy section reconciled (the update check is the app's only network request, opt-out in Settings), SECURITY updated.

## Test plan

- `make ci-check` (lint + Release build) passes.
- Signing identity (identifier + team) is unchanged, so the Accessibility grant survives the Sparkle relaunch — to be confirmed in the update E2E.